### PR TITLE
Added getter and setter for actual input range (float)

### DIFF
--- a/Driver/DriverComponents/InputRange.cpp
+++ b/Driver/DriverComponents/InputRange.cpp
@@ -19,13 +19,28 @@ void InputRange::setInputRange(uint8_t channel, InputRange::Voltage voltage) {
 #endif
 }
 
+void InputRange::setActualInputRange(uint8_t channel, float voltage)
+{
+#ifdef QT_IS_AVAILABLE
+    m_actualInputRangeVoltages[channel] = voltage;
+#endif
+}
+
 InputRange::Voltage InputRange::getInputRange(uint8_t channel) {
     return m_inputRangeVoltages[channel];
+}
+
+float InputRange::getActualInputRange(uint8_t channel)
+{
+    return m_actualInputRangeVoltages[channel];
 }
 
 void InputRange::reset() {
     for(uint8_t channel = 0; channel < 6; channel++) {
         setInputRange(channel, _10);
+#ifdef QT_IS_AVAILABLE
+        emit inputRangeChanged(channel, _10);
+#endif
     }
 }
 

--- a/Driver/DriverComponents/InputRange.h
+++ b/Driver/DriverComponents/InputRange.h
@@ -34,13 +34,25 @@ public:
      * @param voltage input range in Volts
      */
     void setInputRange(uint8_t channel, Voltage voltage);
-
+    /**
+     * @brief setInputRange Sets inputrange for channel
+     * @param channel channel to set inputrange for
+     * @param voltage input range in Volts
+     */
+    void setActualInputRange(uint8_t channel, float voltage);
     /**
      * @brief getInputRange Gets input range for channel in Volts
      * @param channel channel to get inputrange for
      * @return inputrange in volts
      */
     Voltage getInputRange(uint8_t channel);
+
+    /**
+     * @brief getInputRange Gets input range for channel in Volts
+     * @param channel channel to get inputrange for
+     * @return inputrange in volts
+     */
+    float getActualInputRange(uint8_t channel);
 
     void reset() override;
 
@@ -54,6 +66,8 @@ protected:
 
 private:
     std::atomic<Voltage> m_inputRangeVoltages[6];
+    std::atomic<float> m_actualInputRangeVoltages[6];
+
 };
 typedef std::shared_ptr<InputRange> pInputRange;
 

--- a/Driver/ProtoBuf/InputRange/SetInputRange.proto
+++ b/Driver/ProtoBuf/InputRange/SetInputRange.proto
@@ -8,4 +8,5 @@ message SetInputRange {
     }
     uint32 Channel = 1;
     Voltage voltage = 2;
+    float actualVoltage = 3;
 }


### PR DESCRIPTION
Velo had no idea of the actual input range of the channels in Volts, only the user defined ranges. Thus the scaling was wrong.